### PR TITLE
Change the default `--ymin` value of the `$ kurobako plot curve` command.

### DIFF
--- a/src/plot/curve.rs
+++ b/src/plot/curve.rs
@@ -260,13 +260,6 @@ impl<'a> Problem<'a> {
     fn ymin(&self) -> String {
         if let Some(y) = self.opt.ymin {
             y.to_string()
-        } else if self.opt.metric == Metric::BestValue {
-            let y = self.problem.spec.values_domain.variables()[0].range().low();
-            if y.is_finite() {
-                y.to_string()
-            } else {
-                "".to_string()
-            }
         } else {
             "".to_string()
         }


### PR DESCRIPTION
Currently, if `--ymin` isn't specified, the theoretical lower bound of the objective value is used as the default value. However, the theoretical value sometimes isn't realistic and, if so, the resulting plot can be very skewed. To remedy this issue, this PR changes the default behavior to adopt the default handling of Gnuplot.

# Before 

![hpo-bench-protein-81bde99ec2ab16438bf4c7145468df6993c53913a034bd3ee4ee65fdbf1a3bcf](https://user-images.githubusercontent.com/181413/80663388-cdde1080-8ace-11ea-97b2-5144596877e0.png)

# After

![hpo-bench-protein-81bde99ec2ab16438bf4c7145468df6993c53913a034bd3ee4ee65fdbf1a3bcf](https://user-images.githubusercontent.com/181413/80663378-ca4a8980-8ace-11ea-8893-cb321d910794.png)

