### PR TITLE
Redesign optuna solver interface.

### DIFF
--- a/kurobako_solvers/scripts/optuna_solver.py
+++ b/kurobako_solvers/scripts/optuna_solver.py
@@ -1,26 +1,22 @@
 #! /usr/bin/env python3
 import argparse
+import json
+
 from kurobako import solver
 from kurobako.solver.optuna import OptunaSolverFactory
 import optuna
+import optuna.integration
+import optuna.pruners
+import optuna.samplers
 
 ##
 ## (1) Parse command-line arguments
 ##
 parser = argparse.ArgumentParser()
-parser.add_argument("--sampler", choices=["tpe", "random", "skopt", "cma-es"], default="tpe")
-parser.add_argument("--tpe-startup-trials", type=int, default=10)
-parser.add_argument("--tpe-ei-candidates", type=int, default=24)
-parser.add_argument("--tpe-prior-weight", type=float, default=1.0)
-parser.add_argument("--skopt-base-estimator", choices=["GP", "RF", "ET", "GBRT"], default="GP")
-parser.add_argument("--pruner", choices=["median", "asha", "nop", "hyperband"], default="median")
-parser.add_argument("--median-startup-trials", type=int, default=5)
-parser.add_argument("--median-warmup-steps", type=int, default=0)
-parser.add_argument("--asha-min-resource", type=int, default=1)
-parser.add_argument("--asha-reduction-factor", type=int, default=4)
-parser.add_argument("--hyperband-min-resource", type=int, default=1)
-parser.add_argument("--hyperband-reduction-factor", type=int, default=3)
-parser.add_argument("--hyperband-n-brackets", type=int, default=4)
+parser.add_argument("--sampler", type=str, default="TPESampler")
+parser.add_argument("--sampler-kwargs", type=str, default="{}")
+parser.add_argument("--pruner", type=str, default="MedianPruner")
+parser.add_argument("--pruner-kwargs", type=str, default="{}")
 parser.add_argument("--loglevel", choices=["debug", "info", "warning", "error"])
 parser.add_argument("--direction", choices=["minimize", "maximize"], default="minimize")
 parser.add_argument("--use-discrete-uniform", action="store_true")
@@ -41,41 +37,35 @@ def create_study(seed):
     elif args.loglevel == "error":
         optuna.logging.set_verbosity(optuna.logging.ERROR)
 
-    if args.sampler == "random":
-        sampler = optuna.samplers.RandomSampler(seed=seed)
-    elif args.sampler == "tpe":
-        sampler = optuna.samplers.TPESampler(
-            n_startup_trials=args.tpe_startup_trials,
-            n_ei_candidates=args.tpe_ei_candidates,
-            prior_weight=args.tpe_prior_weight,
-            seed=seed,
-        )
-    elif args.sampler == "skopt":
-        skopt_kwargs = {"base_estimator": args.skopt_base_estimator}
-        sampler = optuna.integration.SkoptSampler(skopt_kwargs=skopt_kwargs)
-    elif args.sampler == "cma-es":
-        sampler = optuna.samplers.CmaEsSampler(seed=seed)
-    else:
-        raise ValueError("Unknown sampler: {}".format(args.sampler))
+    # Sampler.
+    sampler_cls = getattr(
+        optuna.samplers, args.sampler, getattr(optuna.integration, args.sampler, None)
+    )
+    if sampler_cls is None:
+        raise ValueError("Unknown sampler: {}.".format(args.sampler))
 
-    if args.pruner == "median":
-        pruner = optuna.pruners.MedianPruner(
-            n_startup_trials=args.median_startup_trials, n_warmup_steps=args.median_warmup_steps
-        )
-    elif args.pruner == "asha":
-        pruner = optuna.pruners.SuccessiveHalvingPruner(
-            min_resource=args.asha_min_resource, reduction_factor=args.asha_reduction_factor
-        )
-    elif args.pruner == "hyperband":
-        pruner = optuna.pruners.HyperbandPruner(
-            min_resource=args.hyperband_min_resource,
-            reduction_factor=args.hyperband_reduction_factor,
-            n_brackets=args.hyperband_n_brackets,
-        )
-    elif args.pruner == "nop":
-        pruner = optuna.pruners.NopPruner()
-    else:
-        raise ValueError("Unknown pruner: {}".format(args.pruner))
+    sampler_kwargs = json.loads(args.sampler_kwargs)
+    try:
+        sampler_kwargs["seed"] = seed
+        sampler = sampler_cls(**sampler_kwargs)
+    except:
+        del sampler_kwargs["seed"]
+        sampler = sampler_cls(**sampler_kwargs)
+
+    # Pruner.
+    pruner_cls = getattr(
+        optuna.pruners, args.pruner, getattr(optuna.integration, args.pruner, None)
+    )
+    if pruner_cls is None:
+        raise ValueError("Unknown pruner: {}.".format(args.pruner))
+
+    pruner_kwargs = json.loads(args.pruner_kwargs)
+    try:
+        pruner_kwargs["seed"] = seed
+        pruner = pruner_cls(**pruner_kwargs)
+    except:
+        del pruner_kwargs["seed"]
+        pruner = pruner_cls(**pruner_kwargs)
 
     return optuna.create_study(sampler=sampler, pruner=pruner, direction=args.direction)
 


### PR DESCRIPTION
The current optuna solver interface isn't so flexible and cannot reflect the interface changes of Optuna's samplers and pruners automatically. 
This PR redesigns the interface to resolve the problem. In the new design, you can specify any sampler and pruner defined by Optuna as follows:
```
# Specify the class name and its arguments of the target sampler (and/or pruner).
# You can omit the `--xxx-kwargs` argument if you want to use the default arguments.
$ kurobako solver optuna \
    --sampler TPESampler --sampler-kwargs '{"n_startup_trials": 3}' \
    --pruner HyperbandPruner --pruner-kwargs '{"max_resource": 100}'
```
By this PR, even when Optuna provides new samplers and pruners in the future, it will no longer be needed to update kurobako to support them.

 