### PR TITLE
Allow plotting hypervolume curve plots

### DIFF
--- a/kurobako_core/src/hypervolume.rs
+++ b/kurobako_core/src/hypervolume.rs
@@ -1,7 +1,7 @@
 //! Helpers for computing hypervolumes.
 
 /// Computes the hypervolume.
-pub fn compute(pts: &Vec<Vec<f64>>, ref_pt: &Vec<f64>) -> f64 {
+pub fn compute(pts: &[Vec<f64>], ref_pt: &[f64]) -> f64 {
     assert!(
         !ref_pt.is_empty(),
         "Reference point must have at least one dimension"
@@ -9,7 +9,7 @@ pub fn compute(pts: &Vec<Vec<f64>>, ref_pt: &Vec<f64>) -> f64 {
     get_hypervolume_recursive(pts, ref_pt)
 }
 
-fn get_hypervolume_recursive(pts: &[Vec<f64>], ref_pt: &Vec<f64>) -> f64 {
+fn get_hypervolume_recursive(pts: &[Vec<f64>], ref_pt: &[f64]) -> f64 {
     match pts.len() {
         1 => get_hypervolume_two_points(&pts[0], &ref_pt),
         2 => {
@@ -30,7 +30,7 @@ fn get_hypervolume_recursive(pts: &[Vec<f64>], ref_pt: &Vec<f64>) -> f64 {
     }
 }
 
-fn get_hypervolume_two_points(pt0: &Vec<f64>, pt1: &Vec<f64>) -> f64 {
+fn get_hypervolume_two_points(pt0: &[f64], pt1: &[f64]) -> f64 {
     assert_eq!(pt0.len(), pt1.len());
     assert!(!pt0.is_empty());
 
@@ -39,7 +39,7 @@ fn get_hypervolume_two_points(pt0: &Vec<f64>, pt1: &Vec<f64>) -> f64 {
         .fold(1.0, |prod, (&crd0, &crd1)| prod * (crd0 - crd1).abs())
 }
 
-fn get_max_coordinates(pt0: &Vec<f64>, pt1: &Vec<f64>) -> Vec<f64> {
+fn get_max_coordinates(pt0: &[f64], pt1: &[f64]) -> Vec<f64> {
     assert_eq!(pt0.len(), pt1.len());
     assert!(!pt0.is_empty());
 
@@ -49,7 +49,7 @@ fn get_max_coordinates(pt0: &Vec<f64>, pt1: &Vec<f64>) -> Vec<f64> {
         .collect()
 }
 
-fn get_exclusive_hypervolume(pt: &Vec<f64>, pts: &[Vec<f64>], ref_pt: &Vec<f64>) -> f64 {
+fn get_exclusive_hypervolume(pt: &[f64], pts: &[Vec<f64>], ref_pt: &[f64]) -> f64 {
     let mut limited_pts: Vec<Vec<f64>> = Vec::new();
 
     if !pts.is_empty() {

--- a/kurobako_core/src/hypervolume.rs
+++ b/kurobako_core/src/hypervolume.rs
@@ -2,7 +2,10 @@
 
 /// Computes the hypervolume.
 pub fn compute(pts: &Vec<Vec<f64>>, ref_pt: &Vec<f64>) -> f64 {
-    assert!(!ref_pt.is_empty(), "Reference point must have at least one dimension");
+    assert!(
+        !ref_pt.is_empty(),
+        "Reference point must have at least one dimension"
+    );
     get_hypervolume_recursive(pts, ref_pt)
 }
 

--- a/kurobako_core/src/hypervolume.rs
+++ b/kurobako_core/src/hypervolume.rs
@@ -2,9 +2,7 @@
 
 /// Computes the hypervolume.
 pub fn compute(pts: &Vec<Vec<f64>>, ref_pt: &Vec<f64>) -> f64 {
-    if ref_pt.is_empty() {
-        panic!("Reference point must have at least one dimension");
-    }
+    assert!(!ref_pt.is_empty(), "Reference point must have at least one dimension");
     get_hypervolume_recursive(pts, ref_pt)
 }
 

--- a/kurobako_core/src/hypervolume.rs
+++ b/kurobako_core/src/hypervolume.rs
@@ -52,7 +52,7 @@ fn get_max_coordinates(pt0: &Vec<f64>, pt1: &Vec<f64>) -> Vec<f64> {
 fn get_exclusive_hypervolume(pt: &Vec<f64>, pts: &[Vec<f64>], ref_pt: &Vec<f64>) -> f64 {
     let mut limited_pts: Vec<Vec<f64>> = Vec::new();
 
-    if pts.len() > 0 {
+    if !pts.is_empty() {
         let intersection_pts: Vec<Vec<f64>> = (0..pts.len())
             .map(|i| get_max_coordinates(&pts[i], &pt))
             .collect();

--- a/kurobako_core/src/hypervolume.rs
+++ b/kurobako_core/src/hypervolume.rs
@@ -1,0 +1,186 @@
+//! Helpers for computing hypervolumes.
+
+/// Computes the hypervolume.
+pub fn compute(pts: &Vec<Vec<f64>>, ref_pt: &Vec<f64>) -> f64 {
+    if ref_pt.is_empty() {
+        panic!("Reference point must have at least one dimension");
+    }
+    get_hypervolume_recursive(pts, ref_pt)
+}
+
+fn get_hypervolume_recursive(pts: &[Vec<f64>], ref_pt: &Vec<f64>) -> f64 {
+    match pts.len() {
+        1 => get_hypervolume_two_points(&pts[0], &ref_pt),
+        2 => {
+            get_hypervolume_two_points(&pts[0], &ref_pt)
+                + get_hypervolume_two_points(&pts[1], &ref_pt)
+                - get_hypervolume_two_points(&get_max_coordinates(&pts[0], &pts[1]), &ref_pt)
+        }
+        _ => {
+            // get_exclusive_hypervolume depends on the points being sorted by the first dimension.
+            let mut pts = pts.to_vec();
+            pts.sort_by(|pt0, pt1| pt0[0].partial_cmp(&pt1[0]).unwrap());
+
+            pts.iter()
+                .enumerate()
+                .map(|(i, pt)| get_exclusive_hypervolume(pt, &pts[i + 1..], ref_pt))
+                .sum()
+        }
+    }
+}
+
+fn get_hypervolume_two_points(pt0: &Vec<f64>, pt1: &Vec<f64>) -> f64 {
+    assert_eq!(pt0.len(), pt1.len());
+    assert!(!pt0.is_empty());
+
+    pt0.iter()
+        .zip(pt1.iter())
+        .fold(1.0, |prod, (&crd0, &crd1)| prod * (crd0 - crd1).abs())
+}
+
+fn get_max_coordinates(pt0: &Vec<f64>, pt1: &Vec<f64>) -> Vec<f64> {
+    assert_eq!(pt0.len(), pt1.len());
+    assert!(!pt0.is_empty());
+
+    pt0.iter()
+        .zip(pt1.iter())
+        .map(|(&crd0, &crd1)| crd0.max(crd1))
+        .collect()
+}
+
+fn get_exclusive_hypervolume(pt: &Vec<f64>, pts: &[Vec<f64>], ref_pt: &Vec<f64>) -> f64 {
+    let mut limited_pts: Vec<Vec<f64>> = Vec::new();
+
+    if pts.len() > 0 {
+        let intersection_pts: Vec<Vec<f64>> = (0..pts.len())
+            .map(|i| get_max_coordinates(&pts[i], &pt))
+            .collect();
+
+        limited_pts.push(intersection_pts[0].to_vec());
+
+        // Assert that `pts` is sorted by the first dimension.
+        let mut left = 0;
+        let mut right = 1;
+
+        while right < pts.len() {
+            if intersection_pts[left]
+                .iter()
+                .zip(intersection_pts[right].iter())
+                .any(|(&crd0, &crd1)| crd0 > crd1)
+            {
+                left = right;
+                limited_pts.push(intersection_pts[left].to_vec());
+            }
+            right += 1;
+        }
+    }
+
+    get_hypervolume_two_points(pt, ref_pt)
+        - match limited_pts.len() {
+            0 => 0.0,
+            1 => get_hypervolume_two_points(&limited_pts[0], ref_pt),
+            _ => get_hypervolume_recursive(&limited_pts, ref_pt),
+        }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_float_close(v0: f64, v1: f64) -> bool {
+        let rtol: f64 = 1e-5;
+        let atol: f64 = 1e-8;
+        (v0 - v1).abs() <= atol + rtol * v1.abs()
+    }
+
+    #[test]
+    fn test_1d_single_point() {
+        let pts = vec![vec![0.3]];
+        let ref_pt = vec![1.0];
+        let hv = 0.7;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_1d_multiple_points() {
+        let pts = vec![vec![0.5], vec![0.3], vec![0.2]];
+        let ref_pt = vec![1.0];
+        let hv = 0.8;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_1d_no_points() {
+        let pts = vec![];
+        let ref_pt = vec![1.0];
+        let hv = 0.0;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_2d_single_point() {
+        let pts = vec![vec![0.3, 0.5]];
+        let ref_pt = vec![1.0, 1.0];
+        let hv = 0.35;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_2d_multiple_points() {
+        let mut pts = vec![vec![0.3, 0.5], vec![0.6, 0.2]];
+        let ref_pt = vec![1.0, 1.0];
+        let hv = 0.47;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+
+        // Non-Pareto optimal points do not contribute to the hypervolume.
+        pts.push(vec![0.8, 0.7]);
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+
+        // Points along the Pareto front does similarly not change the hypervolume.
+        pts.push(vec![0.3, 0.8]);
+        pts.push(vec![0.9, 0.2]);
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_2d_no_points() {
+        let pts = vec![];
+        let ref_pt = vec![1.0, 1.0];
+        let hv = 0.0;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_3d_single_point() {
+        let pts = vec![vec![0.5, 0.5, 0.5]];
+        let ref_pt = vec![1.0, 1.0, 1.0];
+        let hv = 0.125;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    fn test_3d_no_points() {
+        let pts = vec![];
+        let ref_pt = vec![1.0, 1.0, 1.0];
+        let hv = 0.0;
+        let hv_computed = compute(&pts, &ref_pt);
+        assert!(is_float_close(hv_computed, hv));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_reference_point() {
+        let pts = vec![vec![0.5, 0.5]];
+        let ref_pt = vec![];
+        let _ = compute(&pts, &ref_pt);
+    }
+}

--- a/kurobako_core/src/lib.rs
+++ b/kurobako_core/src/lib.rs
@@ -8,6 +8,7 @@ pub use error::{Error, ErrorKind};
 
 pub mod domain;
 pub mod epi;
+pub mod hypervolume;
 pub mod json;
 pub mod num;
 pub mod problem;

--- a/src/plot/curve.rs
+++ b/src/plot/curve.rs
@@ -19,12 +19,17 @@ use tempfile::{NamedTempFile, TempPath};
 #[allow(missing_docs)]
 pub enum Metric {
     BestValue,
+    Hypervolume,
     ElapsedTime,
     SolverElapsedTime,
 }
 impl Metric {
-    const POSSIBLE_VALUES: &'static [&'static str] =
-        &["best-value", "elapsed-time", "solver-elapsed-time"];
+    const POSSIBLE_VALUES: &'static [&'static str] = &[
+        "best-value",
+        "hypervolume",
+        "elapsed-time",
+        "solver-elapsed-time",
+    ];
 }
 impl FromStr for Metric {
     type Err = Error;
@@ -32,6 +37,7 @@ impl FromStr for Metric {
     fn from_str(s: &str) -> Result<Self> {
         match s {
             "best-value" => Ok(Metric::BestValue),
+            "hypervolume" => Ok(Metric::Hypervolume),
             "elapsed-time" => Ok(Metric::ElapsedTime),
             "solver-elapsed-time" => Ok(Metric::SolverElapsedTime),
             _ => track_panic!(ErrorKind::InvalidInput, "Unknown metric name: {:?}", s),
@@ -167,6 +173,7 @@ impl<'a> Problem<'a> {
     fn make_gnuplot_script(&self, data_path: &TempPath) -> Result<String> {
         let ylabel = match self.opt.metric {
             Metric::BestValue => self.problem.spec.values_domain.variables()[0].name(),
+            Metric::Hypervolume => "Hypervolume",
             Metric::ElapsedTime => "Cumulative Elapsed Seconds (Ask + Evaluate + Tell)",
             Metric::SolverElapsedTime => "Cumulative Elapsed Seconds (Ask + Tell)",
         };
@@ -320,6 +327,7 @@ impl Solver {
             .iter()
             .map(|study| match opt.metric {
                 Metric::BestValue => study.best_values(),
+                Metric::Hypervolume => study.hypervolumes(),
                 Metric::ElapsedTime => study.elapsed_times(true),
                 Metric::SolverElapsedTime => study.elapsed_times(false),
             })

--- a/src/record/study.rs
+++ b/src/record/study.rs
@@ -202,14 +202,7 @@ impl StudyRecord {
                         .expect("Could not parse the reference point coordinate to float")
                 })
                 .collect(),
-            None => {
-                let n_objectives = trials
-                    .first()
-                    .expect("At least one trial must be finished")
-                    .1
-                    .len();
-                vec![100.0; n_objectives]
-            }
+            None => vec![100.0; self.problem.spec.values_domain.len()],
         };
 
         let mut pts = Vec::new();

--- a/src/record/study.rs
+++ b/src/record/study.rs
@@ -4,6 +4,7 @@ use crate::record::{
 use crate::study::{Scheduling, StudyRecipe};
 use crate::time::DateTime;
 use chrono::Local;
+use kurobako_core::hypervolume;
 use kurobako_core::num::OrderedFloat;
 use kurobako_core::problem::ProblemSpec;
 use kurobako_core::solver::SolverSpec;
@@ -173,6 +174,52 @@ impl StudyRecord {
         }
 
         best_values
+    }
+
+    pub fn hypervolumes(&self) -> BTreeMap<u64, f64> {
+        let mut hypervolumes = BTreeMap::new();
+
+        let problem_steps = self.problem.spec.steps.last();
+        let mut trials = self
+            .trials
+            .iter()
+            .filter_map(|t| {
+                if let (Some(step), Some(value)) = (t.end_step(), t.values(problem_steps)) {
+                    Some((step, value))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        trials.sort_by_key(|t| t.0);
+
+        let ref_pt = match self.problem.spec.attrs.get("reference_point") {
+            Some(ref_pt_str) => ref_pt_str
+                .split(",")
+                .map(|cor| {
+                    cor.parse()
+                        .expect("Could not parse the reference point coordinate to float")
+                })
+                .collect(),
+            None => {
+                let n_objectives = trials
+                    .first()
+                    .expect("At least one trial must be finished")
+                    .1
+                    .len();
+                vec![100.0; n_objectives]
+            }
+        };
+
+        let mut pts = Vec::new();
+        for (step, values) in trials {
+            pts.push(values.to_vec());
+            let hv = hypervolume::compute(&pts, &ref_pt);
+            hypervolumes.insert(step, hv);
+        }
+
+        hypervolumes
     }
 
     pub fn elapsed_times(&self, include_evaluate_time: bool) -> BTreeMap<u64, f64> {


### PR DESCRIPTION
Addresses #22. 

Allows plotting hypervolume curve plots by extending the `plot curve` command. This may be useful when comparing different multi-objective algorithms as a complement to the Pareto front visualization.

#### Usage

```bash
kurobako plot curve --metric hypervolume
```
#### Note

- To compute hypervolumes, a reference point must be given. Currently, it can be specified in the problems `attrs` under the `"reference_point"` key. If omitted, will use a hard-coded reference point.
- A log-scale could improve the visualization.

#### Example

![binh-and-korn-function-b27cc20ba6ac83e36fc412f3f023adbdcbc1f775542a5ade38a005f6ba23ea27](https://user-images.githubusercontent.com/5983694/103472320-93501480-4dcf-11eb-90c9-d2e0c951504d.png)
