### PR TITLE
Add optional reference point to problem

### DIFF
--- a/kurobako_core/src/problem.rs
+++ b/kurobako_core/src/problem.rs
@@ -18,6 +18,7 @@ pub struct ProblemSpecBuilder {
     params: Vec<VariableBuilder>,
     values: Vec<VariableBuilder>,
     steps: Vec<u64>,
+    reference_point: Option<Params>,
 }
 impl ProblemSpecBuilder {
     /// Makes a new `ProblemSpecBuilder` instance.
@@ -28,6 +29,7 @@ impl ProblemSpecBuilder {
             params: Vec::new(),
             values: Vec::new(),
             steps: vec![1],
+            reference_point: None,
         }
     }
 
@@ -64,6 +66,12 @@ impl ProblemSpecBuilder {
         self
     }
 
+    /// Sets the value reference point of this problem.
+    pub fn reference_point(mut self, reference_point: Option<Params>) -> Self {
+        self.reference_point = reference_point;
+        self
+    }
+
     /// Builds a `ProblemSpec` with the given settings.
     pub fn finish(self) -> Result<ProblemSpec> {
         let params_domain = track!(Domain::new(self.params))?;
@@ -76,6 +84,7 @@ impl ProblemSpecBuilder {
             params_domain,
             values_domain,
             steps,
+            reference_point: self.reference_point,
         })
     }
 }
@@ -100,6 +109,9 @@ pub struct ProblemSpec {
     ///
     /// This problem can evaluate a given parameter set at a step in this list.
     pub steps: EvaluableSteps,
+
+    /// Problem reference point.
+    pub reference_point: Option<Params>,
 }
 impl ProblemSpec {
     /// Returns the capabilities required to solver to handle this problem.

--- a/kurobako_core/src/problem.rs
+++ b/kurobako_core/src/problem.rs
@@ -74,6 +74,8 @@ impl ProblemSpecBuilder {
 
     /// Builds a `ProblemSpec` with the given settings.
     pub fn finish(self) -> Result<ProblemSpec> {
+        self.validate()?;
+
         let params_domain = track!(Domain::new(self.params))?;
         let values_domain = track!(Domain::new(self.values))?;
         let steps = track!(EvaluableSteps::new(self.steps))?;
@@ -86,6 +88,20 @@ impl ProblemSpecBuilder {
             steps,
             reference_point: self.reference_point,
         })
+    }
+
+    fn validate(&self) -> Result<()> {
+        if let Some(reference_point) = &self.reference_point {
+            if reference_point.len() != self.values.len() {
+                track_panic!(
+                    ErrorKind::InvalidInput,
+                    "Unexpected dimensions of values {} and reference point {}",
+                    self.values.len(),
+                    reference_point.len()
+                )
+            }
+        }
+        Ok(())
     }
 }
 

--- a/kurobako_core/src/problem.rs
+++ b/kurobako_core/src/problem.rs
@@ -74,7 +74,7 @@ impl ProblemSpecBuilder {
 
     /// Builds a `ProblemSpec` with the given settings.
     pub fn finish(self) -> Result<ProblemSpec> {
-        self.validate()?;
+        track!(self.validate())?;
 
         let params_domain = track!(Domain::new(self.params))?;
         let values_domain = track!(Domain::new(self.values))?;
@@ -92,14 +92,14 @@ impl ProblemSpecBuilder {
 
     fn validate(&self) -> Result<()> {
         if let Some(reference_point) = &self.reference_point {
-            if reference_point.len() != self.values.len() {
-                track_panic!(
-                    ErrorKind::InvalidInput,
-                    "Unexpected dimensions of values {} and reference point {}",
-                    self.values.len(),
-                    reference_point.len()
-                )
-            }
+            track_assert_eq!(
+                reference_point.len(),
+                self.values.len(),
+                ErrorKind::InvalidInput,
+                "Unexpected dimensions of values {} and reference point {}",
+                self.values.len(),
+                reference_point.len()
+            )
         }
         Ok(())
     }

--- a/kurobako_problems/src/zdt.rs
+++ b/kurobako_problems/src/zdt.rs
@@ -54,7 +54,7 @@ impl ProblemFactory for ZdtProblemFactory {
                 "paper",
                 "Zitzler, Eckart, Kalyanmoy Deb, and Lothar Thiele. \"Comparison of multiobjective \
                  evolutionary algorithms: Empirical results.\" Evolutionary computation 8.2 (2000): 173-195."
-            ).value(domain::var("f1")).value(domain::var("f2"));
+            ).value(domain::var("f1")).value(domain::var("f2")).reference_point(Some(Params::new(vec![11.0, 11.0])));
 
         for (i, range) in self.zdt.ranges().into_iter().enumerate() {
             spec = spec.param(domain::var(&format!("x{}", i)).range(range));

--- a/src/record/study.rs
+++ b/src/record/study.rs
@@ -192,14 +192,8 @@ impl StudyRecord {
 
         trials.sort_by_key(|t| t.0);
 
-        let ref_pt = match self.problem.spec.attrs.get("reference_point") {
-            Some(ref_pt_str) => ref_pt_str
-                .split(',')
-                .map(|cor| {
-                    cor.parse()
-                        .expect("Could not parse the reference point coordinate to float")
-                })
-                .collect(),
+        let ref_pt = match &self.problem.spec.reference_point {
+            Some(reference_point) => reference_point.to_vec(),
             None => vec![100.0; self.problem.spec.values_domain.len()],
         };
 


### PR DESCRIPTION
Introduces a reference point field `reference_point` to Kurobako's problems. Prior to this change, the reference points could be specified via `attrs` which was somewhat ad-hoc. This PR also adds an actual reference point to ZDT for demonstrational purpose.

This field is 

- read from when plotting hypervolumes.
- is optional. If `None`, plotting will fall back to a hard-coded point.