### PR TITLE
Keep only one generation of process cache

### DIFF
--- a/kurobako_core/src/epi/problem/external_program.rs
+++ b/kurobako_core/src/epi/problem/external_program.rs
@@ -8,7 +8,6 @@ use crate::{Error, ErrorKind, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{self, AtomicU64};
@@ -17,8 +16,8 @@ use std::thread_local;
 use structopt::StructOpt;
 
 thread_local! {
-    static FACTORIES: RefCell<HashMap<Vec<u8>, ExternalProgramProblemFactory>> =
-        RefCell::new(HashMap::new());
+    static FACTORY_CACHE : RefCell<Option<(Vec<u8>, ExternalProgramProblemFactory)>> =
+        RefCell::new(None);
 }
 
 /// Recipe for the problem implemented by an external program.
@@ -78,13 +77,17 @@ impl ProblemRecipe for ExternalProgramProblemRecipe {
     type Factory = ExternalProgramProblemFactory;
 
     fn create_factory(&self, registry: &FactoryRegistry) -> Result<Self::Factory> {
-        FACTORIES.with(|f| {
+        FACTORY_CACHE.with(|f| {
             let mut f = f.borrow_mut();
             let key = self.cache_key();
-            if !f.contains_key(&key) {
-                f.insert(key.clone(), track!(self.create_new_factory(registry))?);
+
+            if let Some((k, factory)) = f.as_ref(){
+                if k == &key{
+                    return Ok(factory.clone());
+                }
             }
-            Ok(f[&key].clone())
+            *f = Some((key.clone(), track!(self.create_new_factory(registry))?));
+            return Ok(f.as_ref().unwrap().1.clone());
         })
     }
 }

--- a/kurobako_core/src/epi/problem/external_program.rs
+++ b/kurobako_core/src/epi/problem/external_program.rs
@@ -86,7 +86,7 @@ impl ProblemRecipe for ExternalProgramProblemRecipe {
                     return Ok(factory.clone());
                 }
             }
-            *f = Some((key.clone(), track!(self.create_new_factory(registry))?));
+            *f = Some((key, track!(self.create_new_factory(registry))?));
             return Ok(f.as_ref().unwrap().1.clone());
         })
     }

--- a/kurobako_core/src/epi/problem/external_program.rs
+++ b/kurobako_core/src/epi/problem/external_program.rs
@@ -81,8 +81,8 @@ impl ProblemRecipe for ExternalProgramProblemRecipe {
             let mut f = f.borrow_mut();
             let key = self.cache_key();
 
-            if let Some((k, factory)) = f.as_ref(){
-                if k == &key{
+            if let Some((k, factory)) = f.as_ref() {
+                if k == &key {
                     return Ok(factory.clone());
                 }
             }

--- a/src/study.rs
+++ b/src/study.rs
@@ -106,8 +106,8 @@ impl StudiesRecipe {
     /// Returns a iterator that iterates over the study recipes specified by this recipe.
     pub fn studies(&self) -> impl Iterator<Item = StudyRecipe> {
         let mut studies = Vec::new();
-        for i in 0..self.repeats {
-            for problem in &self.problems {
+        for problem in &self.problems {
+            for i in 0..self.repeats {
                 for solver in &self.solvers {
                     let seed = self.seed.map(|s| s + i as u64);
                     let study = StudyRecipe {


### PR DESCRIPTION
Originally, Kurobako caches all processes that are opened by `ExternalProgramProblemFactory`. This is for reducing the overhead of creating processes and loading datasets.

However, this behavior can cause a problem when large datasets are loaded in the children processes. Because Kurobako never closes processes even after those processes become unnecessary, all datasets are eventually loaded on memory and that can eat up all memory on the system. 

We propose the following changes that mitigate this issue.
* Only keep one generation of cache per thread. In other words, if the command is different from the last one, close the old process.
* Reorder the output of `kurobako studies` such that the same command is executed consecutively. This is intended to maximize cache efficiency.